### PR TITLE
Add index to columns.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,12 @@ under.
 * Each column is created as ``varchar 255`` by default. However it is possible to
 override it by setting the header in the CSV file.
 * The first column is treated as the primary column
+* Each column which has ``index:TRUE`` in the header, will be added to the table index, This will make for a faster migration if you need to use the ``unique ID`` for entity-reference.
 * In the SQL a serial ``id`` column is created
 
-| Unique ID | Amount&#124;type:int&#124;length:11&#124;default:0| Body&#124;type:text&#124;size:big | User  |
-| --------- | --------------------------------------------------| ----------------------------------| ----- |
-| title1    | 3000                                              | Some long text, that might even have line breaks. | user1 |
+| Unique ID&#124;index:TRUE | Amount&#124;type:int&#124;length:11&#124;default:0| Body&#124;type:text&#124;size:big | User  |
+| -------------- | --------------------------------------------------| ----------------------------------| ----- |
+| title1         | 3000 | Some long text, that might even have line breaks. | user1 |
 
 The complex column will be translated in the DB to an ``amount`` column type
 ``int(11)`` where ``NULL`` value is allowed.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ override it by setting the header in the CSV file.
  The first column of each table is added to the index by default unless stated otherwise (``index:FALSE``) in the header
  This will make for a faster migration if you need to use any column as key for referencing other entities.
 
-| Unique ID&#124;index:FALSE | Amount&#124;type:int&#124;length:11&#124;default:0| Body&#124;type:text&#124;size:big | User;index:TRUE  |
+| Unique ID&#124;index:FALSE | Amount&#124;type:int&#124;length:11&#124;default:0| Body&#124;type:text&#124;size:big | User&#124;index:TRUE  |
 | -------------------------- | --------------------------------------------------| ----------------------------------| ----- |
 | title1                     | 3000                                              | Some long text, that might even have line breaks. | user1 |
 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ under.
 * Each column is created as ``varchar 255`` by default. However it is possible to
 override it by setting the header in the CSV file.
 * The first column is treated as the primary column
-* Each column which has ``index:TRUE`` in the header, will be added to the table index, This will make for a faster migration if you need to use the ``unique ID`` for entity-reference.
 * In the SQL a serial ``id`` column is created
+* Index can be added to each column by adding ``index:TRUE`` to the column's header, This will make for a faster migration if you need to use the ``unique ID`` for entity-reference.
 
 | Unique ID&#124;index:TRUE | Amount&#124;type:int&#124;length:11&#124;default:0| Body&#124;type:text&#124;size:big | User  |
 | ------------------------- | --------------------------------------------------| ----------------------------------| ----- |

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ override it by setting the header in the CSV file.
 * In the SQL a serial ``id`` column is created
 
 | Unique ID&#124;index:TRUE | Amount&#124;type:int&#124;length:11&#124;default:0| Body&#124;type:text&#124;size:big | User  |
-| -------------- | --------------------------------------------------| ----------------------------------| ----- |
-| title1         | 3000 | Some long text, that might even have line breaks. | user1 |
+| ------------------------- | --------------------------------------------------| ----------------------------------| ----- |
+| title1                    | 3000                                              | Some long text, that might even have line breaks. | user1 |
 
 The complex column will be translated in the DB to an ``amount`` column type
 ``int(11)`` where ``NULL`` value is allowed.

--- a/README.md
+++ b/README.md
@@ -14,11 +14,13 @@ under.
 override it by setting the header in the CSV file.
 * The first column is treated as the primary column
 * In the SQL a serial ``id`` column is created
-* Index can be added to each column by adding ``index:TRUE`` to the column's header, This will make for a faster migration if you need to use the ``unique ID`` for entity-reference.
+* Index can be added to any column by adding ``index:TRUE`` to the column's header,
+ The first column of each table is added to the index by default unless stated otherwise (``index:FALSE``) in the header
+ This will make for a faster migration if you need to use any column as key for referencing other entities.
 
-| Unique ID&#124;index:TRUE | Amount&#124;type:int&#124;length:11&#124;default:0| Body&#124;type:text&#124;size:big | User  |
-| ------------------------- | --------------------------------------------------| ----------------------------------| ----- |
-| title1                    | 3000                                              | Some long text, that might even have line breaks. | user1 |
+| Unique ID&#124;index:FALSE | Amount&#124;type:int&#124;length:11&#124;default:0| Body&#124;type:text&#124;size:big | User;index:TRUE  |
+| -------------------------- | --------------------------------------------------| ----------------------------------| ----- |
+| title1                     | 3000                                              | Some long text, that might even have line breaks. | user1 |
 
 The complex column will be translated in the DB to an ``amount`` column type
 ``int(11)`` where ``NULL`` value is allowed.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ override it by setting the header in the CSV file.
 * The first column is treated as the primary column
 * In the SQL a serial ``id`` column is created
 * Index can be added to any column by adding ``index:TRUE`` to the column's header,
- The first column of each table is added to the index by default unless stated otherwise (``index:FALSE``) in the header
+ The first column of each table is added to the index by default unless stated otherwise (``index:FALSE``) in the header,
  This will make for a faster migration if you need to use any column as key for referencing other entities.
 
 | Unique ID&#124;index:FALSE | Amount&#124;type:int&#124;length:11&#124;default:0| Body&#124;type:text&#124;size:big | User&#124;index:TRUE  |

--- a/csv2sql.drush.inc
+++ b/csv2sql.drush.inc
@@ -105,11 +105,18 @@ function csv2sql_create_db($table_name, $header = array(), $drop_existing = TRUE
     $col_info = array();
     $col_name = csv2sql_get_column_name($header_info[0]);
 
+    // Add the first column to index.
+    if ($first_col && !in_array('index:false', array_map('strtolower', $header_info))) {
+      $index_columns[] = $col_name;
+    }
+
     // Allow passing complex headers,
     // e.g. "Amount|type:int|length:11|not null:false"
     // Which will translate to a column "amount" of type int(11) and NULL value
     // is allowed.
-    // Table indexing is also passed in the headers.
+    // Index the first column in the table as a default,
+    // unless stated otherwise in the column header (index:FALSE),
+    // Add other columns to index if stated in the header (index:TRUE).
     if (!empty($header_info[1])) {
       $properties = $header_info;
       // Remove the column name.
@@ -118,9 +125,13 @@ function csv2sql_create_db($table_name, $header = array(), $drop_existing = TRUE
       foreach ($properties as $property) {
         list($key, $value) = explode(':', $property);
         // Check which columns needs to be added to index.
-        if (strtolower($key) == 'index' && strtoupper($value) == 'TRUE') {
-          // Add the column to the table index.
-          $index_columns[] = $col_name;
+        // Index can't go into the field properties (It's added to table's properties).
+        if (strtolower($key) == 'index') {
+          // Add to index only if index is set to TRUE and it's not the first column.
+          if (strtoupper($value) == 'TRUE' && !$first_col) {
+            // Add the column to the table index.
+            $index_columns[] = $col_name;
+          }
         }
         else {
           $col_info[$key] = $value;
@@ -141,6 +152,7 @@ function csv2sql_create_db($table_name, $header = array(), $drop_existing = TRUE
     }
 
     $fields_info[$col_name] = $col_info;
+    $first_col = FALSE;
   }
 
   if ($drop_existing) {

--- a/csv2sql.drush.inc
+++ b/csv2sql.drush.inc
@@ -96,15 +96,20 @@ function csv2sql_create_db($table_name, $header = array(), $drop_existing = TRUE
 
   $first_col = TRUE;
 
+  // The default index for each table.
+  $index_columns = array('id');
+
   // Get the column properties.
   foreach ($header as $col) {
     $header_info = explode('|', $col);
     $col_info = array();
+    $col_name = csv2sql_get_column_name($header_info[0]);
 
     // Allow passing complex headers,
     // e.g. "Amount|type:int|length:11|not null:false"
     // Which will translate to a column "amount" of type int(11) and NULL value
     // is allowed.
+    // Table indexing is also passed in the headers.
     if (!empty($header_info[1])) {
       $properties = $header_info;
       // Remove the column name.
@@ -112,7 +117,14 @@ function csv2sql_create_db($table_name, $header = array(), $drop_existing = TRUE
 
       foreach ($properties as $property) {
         list($key, $value) = explode(':', $property);
-        $col_info[$key] = $value;
+        // Check which columns needs to be added to index.
+        if (strtolower($key) == 'index' && strtoupper($value) == 'TRUE') {
+          // Add the column to the table index.
+          $index_columns[] = $col_name;
+        }
+        else {
+          $col_info[$key] = $value;
+        }
       }
     }
 
@@ -128,7 +140,6 @@ function csv2sql_create_db($table_name, $header = array(), $drop_existing = TRUE
       );
     }
 
-    $col_name = csv2sql_get_column_name($header_info[0]);
     $fields_info[$col_name] = $col_info;
   }
 
@@ -139,7 +150,7 @@ function csv2sql_create_db($table_name, $header = array(), $drop_existing = TRUE
 
   $table_schema = array(
     'fields' => $fields_info,
-    'primary key' => array('id'),
+    'primary key' => $index_columns,
   );
 
   db_create_table($table_name, $table_schema);


### PR DESCRIPTION
#6

By adding `index:TRUE` to any column, it will be added to the table index as a primary key.
![selection_098](https://cloud.githubusercontent.com/assets/7369740/5832929/0bc65290-a155-11e4-93b5-e3b90a90fccb.png)

The Tables indexes after creation:
![selection_099](https://cloud.githubusercontent.com/assets/7369740/5832950/5f9795b4-a155-11e4-91a8-19f1b1e716ba.png)

@amitaibu PR is ready for code review.
