### PR TITLE
Display row ID on insert error

### DIFF
--- a/csv2sql.drush.inc
+++ b/csv2sql.drush.inc
@@ -198,12 +198,13 @@ function csv2sql_create_db($table_name, $header = array(), $drop_existing = TRUE
  */
 function csv2sql_insert_row_to_table($table_name, $row) {
   try {
-    db_insert($table_name)
+    return db_insert($table_name)
       ->fields($row)
       ->execute();
   }
   catch (Exception $exception) {
     drush_log(format_string('Error in row #@row: @message', array('@row' => $row['_id'], '@message' => $exception->getMessage())), 'error');
+    return FALSE;
   }
 }
 

--- a/csv2sql.drush.inc
+++ b/csv2sql.drush.inc
@@ -185,7 +185,6 @@ function csv2sql_create_db($table_name, $header = array(), $drop_existing = TRUE
   return array_values($headers);
 }
 
-
 /**
  * Insert a single row to the table.
  *
@@ -198,9 +197,14 @@ function csv2sql_create_db($table_name, $header = array(), $drop_existing = TRUE
  *   TRUE if the insert operation was successful.
  */
 function csv2sql_insert_row_to_table($table_name, $row) {
-  return db_insert($table_name)
-    ->fields($row)
-    ->execute();
+  try {
+    db_insert($table_name)
+      ->fields($row)
+      ->execute();
+  }
+  catch (Exception $exception) {
+    drush_log(format_string('Error in row #@row: @message', array('@row' => $row['_id'], '@message' => $exception->getMessage())), 'error');
+  }
 }
 
 /**


### PR DESCRIPTION
This will also cause the command to list all problematic row IDs, instead of just showing the stack of the first error.
