### PR TITLE
Remove escape symbols.

### DIFF
--- a/csv2sql.drush.inc
+++ b/csv2sql.drush.inc
@@ -72,7 +72,7 @@ function drush_csv2sql($csv_path) {
       $row = array();
       foreach ($data as $delta => $value) {
         $header_col = $headers[$delta];
-        $row[$header_col] = $value;
+        $row[$header_col] = str_replace('\"', '"', $value);
       }
       csv2sql_insert_row_to_table($table_name, $row);
       $row_number++;


### PR DESCRIPTION
When creating CSV - if we have `"` inside the value - we should escape it - `\"`, but in the values in the SQL-table we should have the clear value.
